### PR TITLE
Added ability for excluding a particular marker from getting clustered

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -70,7 +70,7 @@ export default class MapWithClustering extends Component {
                 this.state.numberOfMarkers = size;
                 markerKey = 0;
                 newArray.map((item) => {
-                    if (item.props && item.props.coordinate) {
+                    if (item.props && item.props.coordinate && !item.props.disableClustering) {
                         this.state.markers.add({
                             key: markerKey,
                             belly: new Set(),


### PR DESCRIPTION
This can be useful is we want to show a current location custom marker but don't want to get it clustered with rest of the markers.