### PR TITLE
renders custom markers/pins now 

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -147,7 +147,7 @@ export default class MapWithClustering extends Component {
             for(let i = 0; i < this.state.markers.length; i++){
                 this.state.markersOnMap.push(
                     <CustomMarker key = {i} {...this.state.markers[i]}>
-                        { this.state.markers[i].properties.point_count === 0 ?  this.state.markers[i].props.children : null }
+                        { cluster[i].properties.point_count === 0 ?  cluster[i] : null }
                     </CustomMarker>
                 );
             }


### PR DESCRIPTION
Before making this change, the library would not render my custom pins. It would just render the generic pins. If this change is not optimal, kindly recommend a better solution. 