### PR TITLE
Allows for custom pins/markers to be dropped in

### DIFF
--- a/MapView/CustomMarker.js
+++ b/MapView/CustomMarker.js
@@ -123,15 +123,8 @@ export default class CustomMarker extends Component {
                     </Marker>
                 );
             }
-        }else{
-            return(
-                <Marker
-                    key = {isCluster}
-                    coordinate = {coordinates}
-                    {...this.state.props}>
-                    {htmlElement}
-                </Marker>
-            );
+        } else {
+            return (htmlElement);
         }
     }
 }

--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -147,7 +147,7 @@ export default class MapWithClustering extends Component {
             for(let i = 0; i < this.state.markers.length; i++){
                 this.state.markersOnMap.push(
                     <CustomMarker key = {i} {...this.state.markers[i]}>
-                        { this.state.markers[i].properties.point_count === 0 ?  this.state.markers[i].props.children : null }
+                        { cluster[i].properties.point_count === 0 ?  cluster[i] : null }
                     </CustomMarker>
                 );
             }

--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -75,6 +75,7 @@ export default class MapWithClustering extends Component {
                 newArray.map((item) => {
                     if (item.props && item.props.coordinate) {
                         this.state.markers.push({
+                            ...item,
                             props:  item.props,
                             properties: {point_count: 0},
                             geometry: {
@@ -138,7 +139,7 @@ export default class MapWithClustering extends Component {
                 this.state.markersOnMap.push(
                     <CustomMarker key = {i} onClusterPress = {this.state.onClusterPress}
                                   customClusterMarkerDesign = {this.props.customClusterMarkerDesign} {...cluster[i]}>
-                        { cluster[i].properties.point_count === 0 ?  cluster[i].props.children : null }
+                        { cluster[i].properties.point_count === 0 ?  cluster[i] : null }
                     </CustomMarker>
 
                 );
@@ -147,7 +148,7 @@ export default class MapWithClustering extends Component {
             for(let i = 0; i < this.state.markers.length; i++){
                 this.state.markersOnMap.push(
                     <CustomMarker key = {i} {...this.state.markers[i]}>
-                        { cluster[i].properties.point_count === 0 ?  cluster[i] : null }
+                        { this.state.markers[i].properties.point_count === 0 ?  this.state.markers[i].props.children : null }
                     </CustomMarker>
                 );
             }


### PR DESCRIPTION
Previously, when I would drop in my custom component, it would only show the generic pin. Now, my custom pins works, and their onPress functions work. I am not sure how this will affect people that dont have custom pins. Feel free to pull down this branch and change accordingly.
Resolves #19 