### PR TITLE
Added reactivity to MapView children

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -8,6 +8,7 @@ import CustomMarker from './CustomMarker';
 export default class MapWithClustering extends Component {
   state = {
     currentRegion: this.props.region,
+    currentChildren: this.props.children,
     clusterStyle: {
       borderRadius: w(15),
       backgroundColor: this.props.clusterColor,
@@ -29,8 +30,19 @@ export default class MapWithClustering extends Component {
     this.createMarkersOnMap();
   }
 
-  componentWillReceiveProps() {
-    this.createMarkersOnMap();
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.children != prevState.currentChildren) {
+      return {
+        currentChildren: nextProps.children
+      };
+    } else {
+      return null
+    }
+  }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.children !== prevProps.children) {
+      this.createMarkersOnMap(this.state.currentChildren);
+    }
   }
 
   onRegionChangeComplete = (region) => {


### PR DESCRIPTION
Fix for #70 #51 
I had replaced deprecated function `componentWillReceiveProp` with new [getDerivedStateFromProps](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops). 
But I added reactivity only for children prop, maybe it should be done for all. I don't know. 