### PR TITLE
Added prop for custom component as cluster marker

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -134,8 +134,9 @@ export default class MapWithClustering extends Component {
       const bBox = this.calculateBBox(this.state.currentRegion);
       let zoom = this.getBoundsZoomLevel(bBox, { height: h(100), width: w(100) });
       const clusters = await this.superCluster.getClusters([bBox[0], bBox[1], bBox[2], bBox[3]], zoom);
-
-      clusteredMarkers = clusters.map(cluster => (<CustomMarker
+      const CustomDefinedMarker = this.props.customDefinedMarker || CustomMarker
+      
+      clusteredMarkers = clusters.map(cluster => (<CustomDefinedMarker
         pointCount={cluster.properties.point_count}
         clusterId={cluster.properties.cluster_id}
         geometry={cluster.geometry}


### PR DESCRIPTION
I added  a prop `customDefinedMarker` in order to be able to pass to `MapView` a custom component to use as cluster marker, with a fallback to the existent custom marker in none is given