### PR TITLE
Fixing marker's callout display on ios after clicking on a cluster

### DIFF
--- a/MapView/CustomMarker.js
+++ b/MapView/CustomMarker.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
-import { Marker } from 'react-native-maps';
+import { Callout, Marker } from 'react-native-maps';
 
 export default class CustomMarker extends Component {
   shouldComponentUpdate(nextProps) {
@@ -23,6 +23,7 @@ export default class CustomMarker extends Component {
               {this.props.pointCount}
             </Text>
           </View>
+          <Callout tooltip />
         </Marker>
       );
     }


### PR DESCRIPTION
On iOS when tapping first on a cluster and then on a marker causes callout to show then to disappear. I reported the issue : https://github.com/react-native-community/react-native-maps/issues/2725.

A quick fix is possible by adding an empty callout in the cluster's marker : `<Callout tooltip :>`.

I realize the issue is not in react-native-map-clustering, but this quick fix would help would probably help a few users who would otherwise have to wait for react-native-maps' fix (if it ever comes).

