### PR TITLE
Fix map bug when crossing longitude 180°

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -54,6 +54,10 @@ export default class MapWithClustering extends Component {
       longitudeDelta
     } = this.state.currentRegion;
 
+    if (region.longitudeDelta < 0) {
+      region.longitudeDelta += 360;
+    }
+
     if (region.longitudeDelta <= 80) {
       if (
         Math.abs(region.latitudeDelta - latitudeDelta) > latitudeDelta / 8 ||


### PR DESCRIPTION
this fixes a bug in which the map moved backwards when you scroll it around longitude 180 meridian