### PR TITLE
Fixed onRegionChangeComplete not fired when clusteringEnabled=false

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -119,6 +119,7 @@ const ClusteredMapView = ({
       onRegionChangeComplete(region, markers);
       updateRegion(region);
     }
+    else onRegionChangeComplete(region);
   };
 
   const _onClusterPress = cluster => () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "react-native-map-clustering",
+  "version": "3.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@mapbox/geo-viewport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geo-viewport/-/geo-viewport-0.4.0.tgz",
+      "integrity": "sha512-5OAXoP8C96Co3UDIzFliSzrK5njb9oG2H/RTMaZUW1swxIZlj3n3A5ccep5XAEIhTWxBLg/Cz48D3rUbAdXwHQ==",
+      "requires": {
+        "@mapbox/sphericalmercator": "~1.1.0"
+      }
+    },
+    "@mapbox/sphericalmercator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
+      "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA=="
+    },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
+    "supercluster": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
+      "requires": {
+        "kdbush": "^3.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
So I discovered this when I was turning off clustering on my map when the number of markers is small and found out that _onRegionChangeComplete_ was never fired. I looked at the source code and found out that you only call the user-defined _onRegionChangeComplete_ method when _SuperCluster_ is present.