### PR TITLE
Forward the mapRef back up the chain

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import MapView from "react-native-map-clustering";
 import { Marker } from "react-native-maps";
 
@@ -36,8 +36,16 @@ const App = () => {
     return markers;
   };
 
+  // Use this mapRef var to call functions on your MapView manually.
+  // ex: mapRef.fitToCoordinates(...)
+  const mapRef = useRef(null)
+
   return (
-    <MapView initialRegion={INITIAL_REGION} style={{ flex: 1 }}>
+    <MapView
+      ref={mapRef}
+      initialRegion={INITIAL_REGION}
+      style={{ flex: 1 }}
+    >
       {_generateMarkers(200)}
     </MapView>
   );

--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useRef,
   forwardRef,
+  useImperativeHandle,
 } from "react";
 import { Dimensions, LayoutAnimation, Platform } from "react-native";
 import MapView, { Marker, Polyline } from "react-native-maps";
@@ -57,6 +58,10 @@ const ClusteredMapView = forwardRef(
     const [isSpiderfier, updateSpiderfier] = useState(false);
     const [clusterChildren, updateClusterChildren] = useState(null);
     const mapRef = useRef();
+
+    useImperativeHandle(ref, () => ({
+      mapView: mapRef.current
+    }));
 
     const propsChildren = useMemo(() => React.Children.toArray(children), [
       children,


### PR DESCRIPTION
The latest release didn't integrate all the changes I had made to forward the `mapRef` to the parent component in #152. This PR makes it so that you can access and use the `ref` property. I've updated the example app to show how to get and use the `ref`.

This change makes sure that we can still access the inner MapView's ref from the component where we create the `ClusteredMapView`.

This allows you to call functions on the `<ClusteredMapView>` like `animateToCoordinate`, and `getCamera`.

[This makes the example I posted about on #152 work properly](https://github.com/venits/react-native-map-clustering/pull/152#issuecomment-625951280). (ping @nikhilkumar6)