### PR TITLE
Fix for 'region' parameter undefined in '_onRegionChangeComplete'

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -125,7 +125,7 @@ const ClusteredMapView = forwardRef(
     }, [isSpiderfier, markers]);
 
     const _onRegionChangeComplete = (region) => {
-      if (superCluster) {
+      if (superCluster && region) {
         const bBox = calculateBBox(region);
         const zoom = returnMapZoom(region, bBox, minZoom);
         const markers = superCluster.getClusters(bBox, zoom);


### PR DESCRIPTION
I ran into this issue when I'm updating a marker and its opacity. 
The onRegionChangeComplete seems to trigger with the region parameter being undefined, triggering an undefined is not an object error and crashing the app.

I've added a condition verifying if region isn't undefined, and if it is the onRegionChangeComplete prop triggers, it fixed my issue and I could still use the onRegionChangeComplete callback.