### PR TITLE
reset region before update bounding box

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -90,7 +90,9 @@ const ClusteredMapView = forwardRef(
       });
 
       superCluster.load(rawData);
-
+      // reset region before update bounding box
+      updateRegion(restProps.region || restProps.initialRegion);
+      
       const bBox = calculateBBox(currentRegion);
       const zoom = returnMapZoom(currentRegion, bBox, minZoom);
       const markers = superCluster.getClusters(bBox, zoom);


### PR DESCRIPTION
This diff fixes issues sometimes encountered when an initial region is set on initial render of the map but no region is set.