### PR TITLE
feature: cluster selection color

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@ declare module "react-native-map-clustering" {
     clusterColor?: string;
     clusterTextColor?: string;
     clusterFontFamily?: string;
+    selectedClusterId?: string;
+    selectedClusterColor?: string;
     spiderLineColor?: string;
     superClusterRef?: React.MutableRefObject<any>;
     mapRef?: (ref: React.Ref<Map>) => void;

--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -196,7 +196,11 @@ const ClusteredMapView = forwardRef(
                 key={`cluster-${marker.id}`}
                 {...marker}
                 onPress={_onClusterPress(marker)}
-                clusterColor={clusterColor}
+                clusterColor={
+                  restProps.selectedClusterId === marker.id
+                    ? restProps.selectedClusterColor
+                    : clusterColor
+                }
                 clusterTextColor={clusterTextColor}
                 clusterFontFamily={clusterFontFamily}
                 tracksViewChanges={tracksViewChanges}


### PR DESCRIPTION
I needed a way to display the cluster selection state. In this case I just added two properties:
```
    selectedClusterId?: string;
    selectedClusterColor?: string;
```
which are compared in the `markers.map` iterator and dynamically sets the color of the marker. To implement, `onClusterPress(cluster)`, save the `cluster.id` to  component state and pass as a prop to the `MapView`. 