### PR TITLE
Fix for multiple spirals on map

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -112,9 +112,12 @@ const ClusteredMapView = forwardRef(
 
       if (isSpiderfier && markers.length > 0) {
         let allSpiderMarkers = [];
-
+        let spiralChildren = []
         markers.map((marker, i) => {
-          let positions = generateSpiral(marker, clusterChildren, markers, i);
+          if(marker.properties.cluster) {
+            spiralChildren = superCluster.getLeaves(marker.properties.cluster_id, Infinity);
+          }
+          let positions = generateSpiral(marker, spiralChildren, markers, i);
           allSpiderMarkers.push(...positions);
         });
 

--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -136,7 +136,7 @@ const ClusteredMapView = forwardRef(
         if (animationEnabled && Platform.OS === "ios") {
           LayoutAnimation.configureNext(layoutAnimationConf);
         }
-        if (zoom >= 17 && markers.length > 0 && clusterChildren) {
+        if (zoom >= 18 && markers.length > 0) {
           if (spiralEnabled) updateSpiderfier(true);
         } else {
           if (spiralEnabled) updateSpiderfier(false);


### PR DESCRIPTION
This PR fixes #177 , where Markers of spirals (markers with the exact same position) are duplicated to every other Spiral on the map. Currently, the only way to update a certain spiral is by pressing the cluster.
This also leads to the problem, that markers are displayed on the wrong position if there are multiple potential spiral clusters in the currently viewed area of the map. 
With the fixes in this PR, it is possible to show the right markers on the spiral without having to press the cluster before. 

Let me know if you need more information on the changes. :)