### PR TITLE
Fix issues (onRegionChangeComplete|restProps.mapRef) is not a function

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -143,10 +143,10 @@ const ClusteredMapView = forwardRef(
         }
         updateMarkers(markers);
         onMarkersChange(markers);
-        onRegionChangeComplete(region, markers);
+        onRegionChangeComplete && onRegionChangeComplete(region, markers);
         updateRegion(region);
       } else {
-        onRegionChangeComplete(region);
+        onRegionChangeComplete && onRegionChangeComplete(region);
       }
     };
 
@@ -177,7 +177,7 @@ const ClusteredMapView = forwardRef(
         ref={(map) => {
           mapRef.current = map;
           if (ref) ref.current = map;
-          restProps.mapRef(map);
+          restProps.mapRef && restProps.mapRef(map);
         }}
         onRegionChangeComplete={_onRegionChangeComplete}
       >


### PR DESCRIPTION
After I added `react-native-map-clustering` to my app I and simply exchanged `import MapView from 'react-native-maps'` with `import MapView from 'react-native-map-clustering'`, I experienced these two issues when running my app:

```
TypeError: restProps.mapRef is not a function. (In 'restProps.mapRef(map)', 'restProps.mapRef' is undefined)
```
and
```
TypeError: onRegionChangeComplete is not a function. (In 'onRegionChangeComplete(region)', 'onRegionChangeComplete' is undefined)
```

I wasn't providing any functions for mapRef and onRegionChangeComplete since these props are optional and I don't require them in my app. I fixed these errors for now by doing this:

```
const dummy = () => {};

<MapView
  ref={map}
  mapRef={dummy}
  onRegionChangeComplete={dummy}
  ...
>
  {...}
</MapView>
```
Cheers!