### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const App = () => {
   return (
     <>
       <MapView
-        ref={mapRef}
+        mapRef={mapRef}
         initialRegion={INITIAL_REGION}
         style={{ flex: 1 }}
       />


### PR DESCRIPTION
This prop really confused me, and does not match what react-native-maps uses. The reference is here: https://github.com/venits/react-native-map-clustering/blob/338d4d1a978f3fbc5a380b791be2d433e36b16cf/index.d.ts#L29, to confirm that the prop is indeed called mapRef. Not sure if this is intentional, but it's confusing since I did not see this mentioned anywhere.