### PR TITLE
Fix modal and LayoutAnimation conflicting issue  (iOS & GoogleMap)

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -7,7 +7,7 @@ import React, {
   forwardRef,
 } from "react";
 import { Dimensions, LayoutAnimation, Platform } from "react-native";
-import MapView, { Marker, Polyline } from "react-native-maps";
+import MapView, { Polyline } from "react-native-maps";
 import SuperCluster from "supercluster";
 import ClusterMarker from "./ClusteredMarker";
 import {
@@ -59,9 +59,10 @@ const ClusteredMapView = forwardRef(
     const [clusterChildren, updateClusterChildren] = useState(null);
     const mapRef = useRef();
 
-    const propsChildren = useMemo(() => React.Children.toArray(children), [
-      children,
-    ]);
+    const propsChildren = useMemo(
+      () => React.Children.toArray(children),
+      [children]
+    );
 
     useEffect(() => {
       const rawData = [];
@@ -133,7 +134,11 @@ const ClusteredMapView = forwardRef(
         const bBox = calculateBBox(region);
         const zoom = returnMapZoom(region, bBox, minZoom);
         const markers = superCluster.getClusters(bBox, zoom);
-        if (animationEnabled && Platform.OS === "ios") {
+        if (
+          animationEnabled &&
+          Platform.OS === "ios" &&
+          restProps.provider !== "google"
+        ) {
           LayoutAnimation.configureNext(layoutAnimationConf);
         }
         if (zoom >= 18 && markers.length > 0 && clusterChildren) {


### PR DESCRIPTION
The LayoutAnimation in this library only works on Apple Maps, so I think it's better to turn off this function on Google Maps.

Related to #257